### PR TITLE
chore: release v0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [0.29.2] - 2026-02-11
+
+### Changed
+
+- Sync .claude/commands with updated planning templates
+- Scoop
+- Update webpage for v0.29.1
+
+### Fixed
+
+- Add integration impact assessment to architect and itemize templates
+- Planning pipeline reliability + hierarchical ID integration
+
+---
+
 ## [0.29.1] - 2026-02-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cub"
-version = "0.29.1"
+version = "0.29.2"
 description = "AI Coding Assistant Loop - autonomous task execution with Claude, Codex, and more"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/cub/__init__.py
+++ b/src/cub/__init__.py
@@ -4,7 +4,7 @@ Cub - AI Coding Assistant Loop
 A CLI tool that wraps AI coding assistants for autonomous task execution.
 """
 
-__version__ = "0.29.1"
+__version__ = "0.29.2"
 
 # Re-export core models for convenience
 from cub.core.config.models import CubConfig


### PR DESCRIPTION
## Release v0.29.2 - Planning process resilience


### Changed

- Sync .claude/commands with updated planning templates
- Scoop
- Update webpage for v0.29.1

### Fixed

- Add integration impact assessment to architect and itemize templates
- Planning pipeline reliability + hierarchical ID integration

---

---
*Auto-generated by `cut-release.sh`*